### PR TITLE
Fix LinkedIn footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,5 @@ header_pages:
   - about.md
   - writing-samples.md
   - resume.md
-minima:
-  social_links:
-    - { "platform": "linkedin", "user_url": "https://linkedin.com/in/lisademske/" }
+
+linkedin_username: lisademske


### PR DESCRIPTION
This adds a change to make the LinkedIn footer appear.

The way this site is currently deployed, it uses specific versions of Jekyll and all the dependencies as listed [here](https://pages.github.com/versions/). Importantly, the Minima theme is pinned to version 2.5.1, and in that version, the config file format for social links was different; see [here](https://github.com/jekyll/minima/tree/v2.5.1#social-networks).

Switching to that legacy format makes the footer appear with the social links:

![image](https://user-images.githubusercontent.com/8521043/208743915-90dd908c-0a0c-4d02-8112-53adbeb767d8.png)
